### PR TITLE
make ScatterSwap hasher lazy load the spinner_map

### DIFF
--- a/lib/scatter_swap.rb
+++ b/lib/scatter_swap.rb
@@ -3,10 +3,10 @@ require "scatter_swap/hasher"
 
 module ScatterSwap
   def self.hash(plain_integer, spin = 0)
-    Hasher.new(plain_integer, spin).hash
+    Hasher.new(spin).hash(plain_integer)
   end
 
   def self.reverse_hash(hashed_integer, spin = 0)
-    Hasher.new(hashed_integer, spin).reverse_hash
+    Hasher.new(spin).reverse_hash(hashed_integer)
   end
 end

--- a/lib/scatter_swap/hasher.rb
+++ b/lib/scatter_swap/hasher.rb
@@ -27,8 +27,8 @@ module ScatterSwap
     # We want a unique map for each place in the original number
     def swapper_map(index)
       # Lazy load the swapper_map for this index
-      if (!_swapper_maps || !_swapper_maps[index])
-        _swapper_maps ||= []
+      if (!@_swapper_maps || !@_swapper_maps[index])
+        @_swapper_maps ||= []
         index_swapper_map = []
 
         array = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -36,10 +36,10 @@ module ScatterSwap
           index_swapper_map << array.rotate!(index + i ^ spin).pop
         end
 
-        _swapper_maps[index] = index_swapper_map
+        @_swapper_maps[index] = index_swapper_map
       end
 
-      return _swapper_maps[index]
+      return @_swapper_maps[index]
     end
 
     # Using a unique map for each of the ten places,
@@ -96,8 +96,8 @@ module ScatterSwap
     end
 
     def build_working_array(original_integer)
-      zero_pad = original_integer.to_s.rjust(10, '0')
-      return zero_pad.split("").collect {|d| d.to_i}
+      zero_pad = original_integer.to_s.rjust(10, '0'.freeze)
+      return zero_pad.chars.collect {|d| d.to_i}
     end
 
     private

--- a/lib/scatter_swap/hasher.rb
+++ b/lib/scatter_swap/hasher.rb
@@ -110,7 +110,7 @@ module ScatterSwap
       rem = original_integer.to_i
       denominator = 1_000_000_000
       index = 0
-      while (rem > 0)
+      while (index < 10)
         zero_pad[index] = rem / denominator
         rem = rem % denominator
         denominator = denominator / 10
@@ -133,6 +133,6 @@ module ScatterSwap
         7 => '7'.freeze,
         8 => '8'.freeze,
         9 => '9'.freeze,
-    }
+    }.freeze
   end
 end

--- a/lib/scatter_swap/hasher.rb
+++ b/lib/scatter_swap/hasher.rb
@@ -21,7 +21,13 @@ module ScatterSwap
     end
 
     def completed_string(working_array)
-      working_array.join
+      str = '0000000000' # Start with an empty string of 10 spaces
+      working_array.each_with_index do |i, idx|
+        if (i != 0)
+          str[idx] = INT_CHAR_LOOKUP[i]
+        end
+      end
+      str
     end
 
     # We want a unique map for each place in the original number
@@ -113,5 +119,18 @@ module ScatterSwap
 
     private
       attr_accessor :_swapper_maps
+
+    INT_CHAR_LOOKUP = {
+        0 => '0'.freeze,
+        1 => '1'.freeze,
+        2 => '2'.freeze,
+        3 => '3'.freeze,
+        4 => '4'.freeze,
+        5 => '5'.freeze,
+        6 => '6'.freeze,
+        7 => '7'.freeze,
+        8 => '8'.freeze,
+        9 => '9'.freeze,
+    }
   end
 end

--- a/lib/scatter_swap/hasher.rb
+++ b/lib/scatter_swap/hasher.rb
@@ -20,8 +20,10 @@ module ScatterSwap
       return completed_string(working_array)
     end
 
+    # Builds the completed_string from the "working_array" of integers. Optimized heavily to improve memory allocation with
+    # INT_CHAR_LOOKUP method
     def completed_string(working_array)
-      str = '0000000000' # Start with an empty string of 10 spaces
+      str = '0000000000'
       working_array.each_with_index do |i, idx|
         if (i != 0)
           str[idx] = INT_CHAR_LOOKUP[i]

--- a/lib/scatter_swap/hasher.rb
+++ b/lib/scatter_swap/hasher.rb
@@ -95,9 +95,20 @@ module ScatterSwap
       @spin || 0
     end
 
+    # Right justifies the integer/string that's passed in creating an array of integers (representing digits in the final ID)
+    # Optimized for using arithmetic to left justify instead of string casting + rjusting
     def build_working_array(original_integer)
-      zero_pad = original_integer.to_s.rjust(10, '0'.freeze)
-      return zero_pad.chars.collect {|d| d.to_i}
+      zero_pad = [0,0,0,0,0,0,0,0,0,0]
+      rem = original_integer.to_i
+      denominator = 1_000_000_000
+      index = 0
+      while (rem > 0)
+        zero_pad[index] = rem / denominator
+        rem = rem % denominator
+        denominator = denominator / 10
+        index += 1
+      end
+      return zero_pad
     end
 
     private

--- a/lib/scatter_swap/hasher.rb
+++ b/lib/scatter_swap/hasher.rb
@@ -1,81 +1,106 @@
 module ScatterSwap
   class Hasher
-    attr_accessor :working_array
-
-    def initialize(original_integer, spin = 0)
-      @original_integer = original_integer
+    def initialize(spin = 0)
       @spin = spin
-      zero_pad = original_integer.to_s.rjust(10, '0')
-      @working_array = zero_pad.split("").collect {|d| d.to_i}
     end
 
     # obfuscates an integer up to 10 digits in length
-    def hash
-      swap
-      scatter
-      completed_string
+    def hash(plain_integer)
+      working_array = build_working_array(plain_integer)
+      working_array = swap(working_array)
+      working_array = scatter(working_array)
+      return completed_string(working_array)
     end
 
     # de-obfuscates an integer
-    def reverse_hash
-      unscatter
-      unswap
-      completed_string
+    def reverse_hash(hashed_integer)
+      working_array = build_working_array(hashed_integer)
+      working_array = unscatter(working_array)
+      working_array = unswap(working_array)
+      return completed_string(working_array)
     end
 
-    def completed_string
-      @working_array.join
+    def completed_string(working_array)
+      working_array.join
     end
 
     # We want a unique map for each place in the original number
     def swapper_map(index)
-      array = (0..9).to_a
-      10.times.collect.with_index do |i|
-        array.rotate!(index + i ^ spin).pop
+      # Lazy load the swapper_map for this index
+      if (!_swapper_maps || !_swapper_maps[index])
+        _swapper_maps ||= []
+        index_swapper_map = []
+
+        array = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        10.times do |i|
+          index_swapper_map << array.rotate!(index + i ^ spin).pop
+        end
+
+        _swapper_maps[index] = index_swapper_map
       end
+
+      return _swapper_maps[index]
     end
 
     # Using a unique map for each of the ten places,
     # we swap out one number for another
-    def swap
-      @working_array = @working_array.collect.with_index do |digit, index|
+    def swap(working_array)
+      swapped_working_array = working_array.collect.with_index do |digit, index|
         swapper_map(index)[digit]
       end
+
+      return swapped_working_array
     end
 
     # Reverse swap
-    def unswap
-      @working_array = @working_array.collect.with_index do |digit, index|
+    def unswap(working_array)
+      unswapped_working_array = working_array.collect.with_index do |digit, index|
         swapper_map(index).rindex(digit)
       end
+
+      return unswapped_working_array
     end
 
     # Rearrange the order of each digit in a reversable way by using the 
     # sum of the digits (which doesn't change regardless of order)
     # as a key to record how they were scattered
-    def scatter
-      sum_of_digits = @working_array.inject(:+).to_i
-      @working_array = 10.times.collect do 
-        @working_array.rotate!(spin ^ sum_of_digits).pop
+    def scatter(working_array)
+      sum_of_digits = working_array.inject(:+).to_i
+      rotation = spin ^ sum_of_digits
+      scattered_working_array = 10.times.collect do
+        working_array.rotate!(rotation).pop
       end
+
+      return scattered_working_array
     end
 
     # Reverse the scatter
-    def unscatter
-      scattered_array = @working_array
+    def unscatter(working_array)
+      scattered_array = working_array
       sum_of_digits = scattered_array.inject(:+).to_i
-      @working_array = []
-      @working_array.tap do |unscatter| 
+      rotation = (sum_of_digits ^ spin) * -1
+      unscattered_working_array = []
+      unscattered_working_array.tap do |unscatter|
         10.times do
-          unscatter.push scattered_array.pop
-          unscatter.rotate! (sum_of_digits ^ spin) * -1
+          unscatter << scattered_array.pop
+          unscatter.rotate!(rotation)
         end
       end
+
+      return unscattered_working_array
     end
 
     # Add some spice so that different apps can have differently mapped hashes
     def spin
       @spin || 0
     end
+
+    def build_working_array(original_integer)
+      zero_pad = original_integer.to_s.rjust(10, '0')
+      return zero_pad.split("").collect {|d| d.to_i}
+    end
+
+    private
+      attr_accessor :_swapper_maps
   end
 end

--- a/spec/scatter_swap_fixtures_spec.rb
+++ b/spec/scatter_swap_fixtures_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+require 'scatter_swap'
+require 'json'
+
+describe "ScatterSwap Known Examples" do
+    fixtures_file = File.read('spec/fixtures/scatter_swap_fixtures.json')
+    fixtures = JSON.parse(fixtures_file)
+
+    describe 'hash and reverses' do
+        it 'hashes and reverse hashes known values predictably' do
+            fixtures.each do |fixture_group|
+                spin = fixture_group['spin']
+                hasher = ScatterSwap::Hasher.new(spin)
+                fixture_group['examples'].each do |example|
+                    plain_id = example[0]
+                    obfuscated_id = example[1]
+                    expect(hasher.hash(plain_id).to_i).to eq(obfuscated_id)
+                    expect(hasher.reverse_hash(obfuscated_id).to_i).to eq(plain_id)
+                end
+            end
+        end
+    end
+end

--- a/spec/scatter_swap_spec.rb
+++ b/spec/scatter_swap_spec.rb
@@ -25,7 +25,7 @@ end
 describe "#swapper_map" do
   before do
     @map_set = []
-    s = ScatterSwap::Hasher.new(1)
+    s = ScatterSwap::Hasher.new
     10.times do |digit|
       @map_set.push s.swapper_map(digit)
     end
@@ -45,22 +45,14 @@ describe "#swapper_map" do
 end
 
 describe "#scatter" do
-  it "should return a number different from original" do
-    100.times do |integer|
-      s = ScatterSwap::Hasher.new(integer)
-      original_array = s.working_array
-      s.scatter
-      s.working_array.should_not == original_array
-    end
-  end
-
   it "should be reversable" do
     100.times do |integer|
-      s = ScatterSwap::Hasher.new(integer)
-      original_array = s.working_array.clone
-      s.scatter
-      s.unscatter
-      s.working_array.should == original_array
+      s = ScatterSwap::Hasher.new
+      working_array = s.build_working_array(integer)
+      original_array = working_array.clone
+      scattered_array = s.scatter(working_array)
+      unscattered_array = s.unscatter(scattered_array)
+      unscattered_array.should == original_array
     end
   end
 end
@@ -68,20 +60,22 @@ end
 describe "#swap" do
   it "should be different from original" do
     100.times do |integer|
-      s = ScatterSwap::Hasher.new(integer)
-      original_array = s.working_array.clone
-      s.swap
-      s.working_array.should_not == original_array
+      s = ScatterSwap::Hasher.new
+      working_array = s.build_working_array(integer)
+      original_array = working_array.clone
+      working_array = s.swap(working_array)
+      working_array.should_not == original_array
     end
   end
 
   it "should be reversable" do
     100.times do |integer|
-      s = ScatterSwap::Hasher.new(integer)
-      original_array = s.working_array.clone
-      s.swap
-      s.unswap
-      s.working_array.should == original_array
+      s = ScatterSwap::Hasher.new
+      working_array = s.build_working_array(integer)
+      original_array = working_array.clone
+      swapped_array = s.swap(working_array)
+      unswapped_array = s.unswap(swapped_array)
+      unswapped_array.should == original_array
     end
   end
-end  
+end


### PR DESCRIPTION
Results below represent running this across a set of IDs. Overall these changes reduce the amount of allocated memory by 10x and increase speed by 5x!

I have also written a spec that uses 3M known obfuscated values for given spins (`User`, `Entity`, `Invoice`) and ensures that the result is the same.

# Before

## Speed (60K IDs)
```
       user     system      total        real
   9.420000   0.370000   9.790000 (  9.808217)
```

## Speed (3M IDs)
```
       user     system      total        real
    405.500000   8.690000 414.190000 (416.325212)
```

## Memory Usage (60K IDs)
```
Total allocated: 1,159,998,278 bytes (11820720 objects)
Total retained:  1858 bytes (9 objects)

allocated memory by gem
-----------------------------------
1150377516  scatter_swap/lib
   ...

allocated memory by file
-----------------------------------
1145577276  /Users/connor/dev/scatter_swap/lib/scatter_swap/hasher.rb
   ...

allocated memory by location
-----------------------------------
 528026400  /Users/connor/dev/scatter_swap/lib/scatter_swap/hasher.rb:33
 311655582  /Users/connor/dev/scatter_swap/lib/scatter_swap/hasher.rb:9
 163208160  /Users/connor/dev/scatter_swap/lib/scatter_swap/hasher.rb:32
  68283414  /Users/connor/dev/scatter_swap/lib/scatter_swap/hasher.rb:27
  19200960  /Users/connor/dev/scatter_swap/lib/scatter_swap/hasher.rb:58
  14400720  /Users/connor/dev/scatter_swap/lib/scatter_swap/hasher.rb:41
  14400720  /Users/connor/dev/scatter_swap/lib/scatter_swap/hasher.rb:48
  14400720  /Users/connor/dev/scatter_swap/lib/scatter_swap/hasher.rb:8
  12000600  /Users/connor/dev/scatter_swap/lib/scatter_swap/hasher.rb:67
   ...

allocated memory by class
-----------------------------------
 480024120  Array
 309615480  Enumerator
 261380678  String
  60963048  Regexp
  33601680  MatchData
   ...
```

# After

## Speed (60K IDs)
```
       user     system      total        real
   1.700000   0.050000   1.750000 (  1.760732)
```

## Speed (3M IDs)
```
       user     system      total        real
  74.200000   0.920000  75.120000 ( 75.482721)
```


## Memory Usage (60K IDs)
```
Total allocated: 88,848,205 bytes (900396 objects)
Total retained:  1270 bytes (6 objects)

allocated memory by gem
-----------------------------------
  79214136  scatter_swap/lib
   ...

allocated memory by file
-----------------------------------
  79214136  /Users/connor/dev/scatter_swap/lib/scatter_swap/hasher.rb
   ...

allocated memory by location
-----------------------------------
  19200960  /Users/connor/dev/scatter_swap/lib/scatter_swap/hasher.rb:76
  14400720  /Users/connor/dev/scatter_swap/lib/scatter_swap/hasher.rb:107
  14400720  /Users/connor/dev/scatter_swap/lib/scatter_swap/hasher.rb:54
  14400720  /Users/connor/dev/scatter_swap/lib/scatter_swap/hasher.rb:63
  12000600  /Users/connor/dev/scatter_swap/lib/scatter_swap/hasher.rb:88
  ...

allocated memory by class
-----------------------------------
  52814424  Array
  21601080  Enumerator
   4819549  String
   ...
```